### PR TITLE
Shortened the display of text in the window

### DIFF
--- a/Filtration.ObjectModel/BlockItemTypes/BaseArmourlBlockItem.cs
+++ b/Filtration.ObjectModel/BlockItemTypes/BaseArmourlBlockItem.cs
@@ -17,7 +17,7 @@ namespace Filtration.ObjectModel.BlockItemTypes
         public override string PrefixText => "BaseArmour";
         public override int MaximumAllowed => 1;
         public override string DisplayHeading => "BaseArmour";
-        public override string SummaryText => "Base Armour " + FilterPredicate;
+        public override string SummaryText => "Base AR " + FilterPredicate;
         public override Color SummaryBackgroundColor => Colors.PaleVioletRed;
         public override Color SummaryTextColor => Colors.White;
         public override BlockItemOrdering SortOrder => BlockItemOrdering.BaseArmour;

--- a/Filtration.ObjectModel/BlockItemTypes/BaseDefencePercentilelBlockItem.cs
+++ b/Filtration.ObjectModel/BlockItemTypes/BaseDefencePercentilelBlockItem.cs
@@ -17,7 +17,7 @@ namespace Filtration.ObjectModel.BlockItemTypes
         public override string PrefixText => "BaseDefencePercentile";
         public override int MaximumAllowed => 1;
         public override string DisplayHeading => "BaseDefencePercentile";
-        public override string SummaryText => "Base Defence Percentile " + FilterPredicate;
+        public override string SummaryText => "Base DP " + FilterPredicate;
         public override Color SummaryBackgroundColor => Colors.Gray;
         public override Color SummaryTextColor => Colors.White;
         public override BlockItemOrdering SortOrder => BlockItemOrdering.BaseDefencePercentile;

--- a/Filtration.ObjectModel/BlockItemTypes/BaseEnergyShieldlBlockItem.cs
+++ b/Filtration.ObjectModel/BlockItemTypes/BaseEnergyShieldlBlockItem.cs
@@ -17,7 +17,7 @@ namespace Filtration.ObjectModel.BlockItemTypes
         public override string PrefixText => "BaseEnergyShield";
         public override int MaximumAllowed => 1;
         public override string DisplayHeading => "BaseEnergyShield";
-        public override string SummaryText => "Base Energy Shield " + FilterPredicate;
+        public override string SummaryText => "Base ES " + FilterPredicate;
         public override Color SummaryBackgroundColor => Colors.RoyalBlue;
         public override Color SummaryTextColor => Colors.White;
         public override BlockItemOrdering SortOrder => BlockItemOrdering.BaseEnergyShield;

--- a/Filtration.ObjectModel/BlockItemTypes/BaseEvasionlBlockItem.cs
+++ b/Filtration.ObjectModel/BlockItemTypes/BaseEvasionlBlockItem.cs
@@ -17,7 +17,7 @@ namespace Filtration.ObjectModel.BlockItemTypes
         public override string PrefixText => "BaseEvasion";
         public override int MaximumAllowed => 1;
         public override string DisplayHeading => "BaseEvasion";
-        public override string SummaryText => "Base Evasion " + FilterPredicate;
+        public override string SummaryText => "Base EV " + FilterPredicate;
         public override Color SummaryBackgroundColor => Colors.DarkOliveGreen;
         public override Color SummaryTextColor => Colors.White;
         public override BlockItemOrdering SortOrder => BlockItemOrdering.BaseEvasion;


### PR DESCRIPTION
 for BaseDefencePercentile (Base DP), BaseArmour (Base AR), BaseEvasion (Base EV), BaseEnergyShield (Base ES)